### PR TITLE
Added overload to Guard.ArgumentIsNotNullOrEmpty that has a predefined message

### DIFF
--- a/Source/Enkoni.Framework/Guard.cs
+++ b/Source/Enkoni.Framework/Guard.cs
@@ -36,6 +36,22 @@ namespace Enkoni.Framework {
     /// <summary>Throws an exception if the tested string argument is <see langword="null"/> or the empty string.</summary>
     /// <param name="argumentValue">Argument value to check.</param>
     /// <param name="argumentName">Name of argument being checked.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="argumentValue"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown if the string is empty.</exception>
+    public static void ArgumentIsNotNullOrEmpty([ValidatedNotNull]string argumentValue, string argumentName) {
+      if(argumentValue == null) {
+        ThrowArgumentNullException(argumentName, null);
+        return;
+      }
+
+      if(argumentValue.Length == 0) {
+        ThrowArgumentException(argumentName, "Value cannot be empty.");
+      }
+    }
+
+    /// <summary>Throws an exception if the tested string argument is <see langword="null"/> or the empty string.</summary>
+    /// <param name="argumentValue">Argument value to check.</param>
+    /// <param name="argumentName">Name of argument being checked.</param>
     /// <param name="message">The message that will be passed to the exception.</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="argumentValue"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown if the string is empty.</exception>

--- a/Source/Test/Enkoni.Framework.Tests/GuardTest.cs
+++ b/Source/Test/Enkoni.Framework.Tests/GuardTest.cs
@@ -58,6 +58,13 @@ namespace Enkoni.Framework.Tests {
       Guard.ArgumentIsNotNullOrEmpty(testArgument, nameof(testArgument), "ExpectedMessage");
     }
 
+    /// <summary>Tests the functionality of the <see cref="Guard.ArgumentIsNotNullOrEmpty(string, string)"/> method.</summary>
+    [TestMethod]
+    public void ArgumentIsNotNullOrEmpty_NoNullNoEmptyStringWithoutMessage_ArgumentDoesNotThrowException() {
+      string testArgument = "someInput";
+      Guard.ArgumentIsNotNullOrEmpty(testArgument, nameof(testArgument));
+    }
+
     /// <summary>Tests the functionality of the <see cref="Guard.ArgumentIsNotNullOrEmpty(string, string, string)"/> method.</summary>
     [TestMethod]
     public void ArgumentIsNotNullOrEmpty_NullStringArgument_ThrowsArgumentNullException() {
@@ -69,6 +76,20 @@ namespace Enkoni.Framework.Tests {
       catch(ArgumentNullException exception) {
         Assert.AreEqual("testArgument", exception.ParamName);
         StringAssert.StartsWith(exception.Message, "ExpectedMessage" + Environment.NewLine);
+      }
+    }
+
+    /// <summary>Tests the functionality of the <see cref="Guard.ArgumentIsNotNullOrEmpty(string, string)"/> method.</summary>
+    [TestMethod]
+    public void ArgumentIsNotNullOrEmpty_NullStringArgumentWithoutMessage_ThrowsArgumentNullException() {
+      string testArgument = null;
+      try {
+        Guard.ArgumentIsNotNullOrEmpty(testArgument, nameof(testArgument));
+        Assert.Fail("An ArgumentNullException was expected");
+      }
+      catch(ArgumentNullException exception) {
+        Assert.AreEqual("testArgument", exception.ParamName);
+        Assert.IsNotNull(exception.Message);
       }
     }
 
@@ -85,6 +106,22 @@ namespace Enkoni.Framework.Tests {
         Assert.AreEqual(typeof(ArgumentException), exception.GetType());
         Assert.AreEqual("testArgument", exception.ParamName);
         StringAssert.StartsWith(exception.Message, "ExpectedMessage" + Environment.NewLine);
+      }
+    }
+
+    /// <summary>Tests the functionality of the <see cref="Guard.ArgumentIsNotNullOrEmpty(string, string)"/> method.</summary>
+    [TestMethod]
+    public void ArgumentIsNotNullOrEmpty_EmptyStringArgumentWithMessage_ThrowsArgumentException() {
+      string testArgument = string.Empty;
+      try {
+        Guard.ArgumentIsNotNullOrEmpty(testArgument, nameof(testArgument));
+        Assert.Fail("An ArgumentException was expected");
+      }
+      catch(ArgumentException exception) {
+        /* Make sure it not some derived exceptioin type */
+        Assert.AreEqual(typeof(ArgumentException), exception.GetType());
+        Assert.AreEqual("testArgument", exception.ParamName);
+        StringAssert.StartsWith(exception.Message, "Value cannot be empty." + Environment.NewLine);
       }
     }
 


### PR DESCRIPTION
This patch adds an overload to Guard.ArgumentIsNotNullOrEmpty that has a predefined english message.  
